### PR TITLE
fix: badge syntax and samples in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,23 @@
 # packageName
 
-[![npm version][npm-version-src]][npm-version-href]
-[![npm downloads][npm-downloads-src]][npm-downloads-href]
-[![Github Actions][github-actions-src]][github-actions-href]
-[![Codecov][codecov-src]][codecov-href]
+[![npm version](npm-version-src)](npm-version-href)
+[![npm downloads](npm-downloads-src)](npm-downloads-href)
+[![Github Actions](github-actions-src)](github-actions-href)
+[![Codecov](codecov-src)](codecov-href)
+
+<!--
+[npm-version-src]: https://img.shields.io/npm/v/packageName?style=flat-square
+[npm-version-href]: https://npmjs.com/package/packageName
+
+[npm-downloads-src]: https://img.shields.io/npm/dm/packageName?style=flat-square
+[npm-downloads-href]: https://npmjs.com/package/packageName
+
+[github-actions-src]: https://img.shields.io/github/workflow/status/unjs/packageName/ci/main?style=flat-square
+[github-actions-href]: https://github.com/unjs/packageName/actions?query=workflow%3Aci
+
+[codecov-src]: https://img.shields.io/codecov/c/gh/unjs/packageName/main?style=flat-square
+[codecov-href]: https://codecov.io/gh/unjs/packageName
+-->
 
 > Package description
 
@@ -44,16 +58,3 @@ const { } = require('packageName')
 Made with 💛
 
 Published under [MIT License](./LICENSE).
-
-<!-- Badges -->
-[npm-version-src]: https://img.shields.io/npm/v/packageName?style=flat-square
-[npm-version-href]: https://npmjs.com/package/packageName
-
-[npm-downloads-src]: https://img.shields.io/npm/dm/packageName?style=flat-square
-[npm-downloads-href]: https://npmjs.com/package/packageName
-
-[github-actions-src]: https://img.shields.io/github/workflow/status/unjs/packageName/ci/main?style=flat-square
-[github-actions-href]: https://github.com/unjs/packageName/actions?query=workflow%3Aci
-
-[codecov-src]: https://img.shields.io/codecov/c/gh/unjs/packageName/main?style=flat-square
-[codecov-href]: https://codecov.io/gh/unjs/packageName


### PR DESCRIPTION
I found that badges in README are not rendered correctly in NPM and GitHub, and that sample URLS are a little too far away from where they are supposed to be used and rendered unnecessarily.

This PR is to fix the badge syntax and comment out sample URLS near the badges.