### PR TITLE
chore: add `@vitest/coverage-c8` and run coverage in `test` script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,5 @@ jobs:
       - run: pnpm install
       - run: pnpm lint
       - run: pnpm build
-      - run: pnpm coverage
+      - run: pnpm vitest --coverage
       - uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,5 @@ jobs:
       - run: pnpm install
       - run: pnpm lint
       - run: pnpm build
-      - run: pnpm vitest --coverage
+      - run: pnpm coverage
       - uses: codecov/codecov-action@v3

--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
     "lint": "eslint --ext .ts,.js,.mjs,.cjs .",
     "prepack": "unbuild",
     "release": "pnpm test && standard-version && git push --follow-tags && pnpm publish",
-    "test": "pnpm lint && vitest run",
-    "coverage": "pnpm lint && vitest run --coverage"
+    "test": "pnpm lint && vitest run --coverage"
   },
   "dependencies": {},
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "lint": "eslint --ext .ts,.js,.mjs,.cjs .",
     "prepack": "unbuild",
     "release": "pnpm test && standard-version && git push --follow-tags && pnpm publish",
-    "test": "pnpm lint && vitest run"
+    "test": "pnpm lint && vitest run",
+    "coverage": "pnpm lint && vitest run --coverage"
   },
   "dependencies": {},
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {},
   "devDependencies": {
     "@nuxtjs/eslint-config-typescript": "latest",
-    "c8": "latest",
+    "@vitest/coverage-c8": "latest",
     "eslint": "latest",
     "standard-version": "latest",
     "typescript": "latest",


### PR DESCRIPTION
This PR is to improve Vitest-related content of template.

- Replace `c8` with `@vitest/coverage-c8` to follow break change of [Vitest@0.22.0](https://github.com/vitest-dev/vitest/releases/tag/v0.22.0)
- Added `coverage` npm script for consistency with others