### PR TITLE
chore: update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
   "extends": [
-    "@nuxtjs"
+    "github>unjs/renovate-config"
   ]
 }


### PR DESCRIPTION
I just applied change of https://github.com/unjs/defu/pull/56 to the template.
Should I apply this change to other unjs repositories too, where `@nuxtjs` is still used?