### PR TITLE
feat: add GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,43 @@
+name: "\U0001F41E Bug report"
+description: Report an issue or bug
+# Labels must be prepared in advance, otherwise no labels are applied
+labels: ["pending triage"]
+body:
+  - type: markdown
+    attributes:
+      value: Thank you for taking the time to fill out this bug report!
+  - type: textarea
+    id: bug-env
+    attributes:
+      label: Environment
+      description: Package and Node.js version can be helpful to investigate issues
+      placeholder: Environment
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Please provide a link to a repo that can reproduce the problem you ran into. A **minimal reproduction** is required unless you are absolutely sure that the issue is obvious and the provided information is enough to understand the problem. If a report is vague (e.g. just a generic error message) and has no reproduction, it will receive a "need reproduction" label. If no reproduction is provided we might close it.
+      placeholder: Reproduction
+    validations:
+      required: true
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is. If you intend to submit a PR for this issue, tell us in the description. Thanks!
+      placeholder: Bug description
+    validations:
+      required: true
+  - type: textarea
+    id: additonal
+    attributes:
+      label: Additional context
+      description: If applicable, add any other context about the problem here.
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Optional if provided reproduction. Please try not to insert an image but copy paste the log text.
+      render: sh

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+# contact_links:
+#   # GitHub Discussions is disabled by default. You should enabled it fist otherwise 404 page is shown.
+#   - name: 💬 Discussions
+#     url: https://github.com/unjs/packageName/discussions
+#     about: Use discussions if you have an idea for improvement and asking questions
+
+#   # You might need this link in case this package is integrated into Nuxt
+#   - name: 🔗 Nuxt related Issues
+#     url: https://github.com/nuxt/framework/issues/new/choose
+#     about: Please open an issue in nuxt/framework to discuss

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,23 @@
+name: "🚀 Feature request"
+description: Suggest a feature or improvement
+# Labels must be prepared in advance, otherwise no labels are applied
+labels: ["pending triage"]
+body:
+  - type: markdown
+    attributes:
+      value: Thank you for taking the time to fill out this feature request!
+  - type: textarea
+    id: feature-description
+    attributes:
+      label: Describe the feature
+      description: A clear and concise description of what you think would be a helpful addition, including the possible use cases and alternatives you have considered. If you have a working prototype or module that implements it, please include a link.
+      placeholder: Feature description
+    validations:
+      required: true
+  - type: checkboxes
+    id: additional-info
+    attributes:
+      label: Additional information
+      description: Additional information that helps us decide how to proceed.
+      options:
+        - label: Would you be willing to help implement this feature?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,38 @@
+<!---
+☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)
+
+Examples:
+ - feat: add something
+ - fix(rollup): change something
+ - docs: fix typo
+-->
+
+### 🔗 Linked issue
+
+<!-- Please ensure there is an open issue and mention its number like "Resolves #123" -->
+
+### ❓ Type of change
+
+<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
+
+- [ ] 📖 Documentation (updates to the documentation or readme)
+- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
+- [ ] 👌 Enhancement (improving an existing functionality like performance)
+- [ ] ✨ New feature (a non-breaking change that adds functionality)
+- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
+
+### 📚 Description
+
+<!-- Describe your changes in detail -->
+<!-- Why is this change required? What problem does it solve? -->
+<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
+
+### 📝 Checklist
+
+<!-- Put an `x` in all the boxes that apply. -->
+<!-- If your change requires a documentation PR, please link it appropriately -->
+<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+
+- [ ] I have linked an issue or discussion.
+- [ ] I have updated the documentation accordingly.
+- [ ] I have updated tests and/or playground accordingly.


### PR DESCRIPTION
Resolves #28

I got emoji reactions to the issue from @pi0 and @danielroe, which is why I created this PR.

I added GitHub Issues/PR templates mainly based on [unjs/nitro](https://github.com/unjs/nitro) with some modifications.

You can check how these templates look like in [NozomuIkuta/unjs-template-playground](https://github.com/NozomuIkuta/unjs-template-playground).