### PR TITLE
fix: add `coverage` directory to `.eslintignore`

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
-dist
 node_modules
+coverage
+dist


### PR DESCRIPTION
I just add `coverage` directory to `.eslintignore` file, otherwise `lint` and `lint:fix` commands fail if `coverage` directory exists.

I also modified the order of directories for it to be consistent with that of `.gitignore`.